### PR TITLE
fix/ (server) - adding .env.example file on server project

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,14 @@
+# Environment variables declared in this file are automatically made available to Prisma.
+# See the documentation for more detail: https://pris.ly/d/prisma-schema#accessing-environment-variables-from-the-schema
+
+# Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
+# See the documentation for all the connection string options: https://pris.ly/d/connection-strings
+
+# For local SQLite, use this one
+# On prisma.schema file, on datasource, you should config: provider = "sqlite"
+DATABASE_URL="file:./dev.db"
+
+
+# For PostgreSQL on Neon.tech, use this one
+# On prisma.schema file, on datasource, you should config: provider = "postgresql"
+# DATABASE_URL=[YOUR_Connection_String - visit neon.tech to get your db dev branch]


### PR DESCRIPTION
.env.example file on server project
to be used to create a .env file on root of server folder 