### PR TITLE
fix: add dotenv.config() to passportConfig.ts

### DIFF
--- a/server/src/config/passportConfig.ts
+++ b/server/src/config/passportConfig.ts
@@ -2,6 +2,9 @@ import passport from 'passport';
 import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
 import dotenv from 'dotenv';
 
+// Load environment variables from the .env file
+dotenv.config();
+
 passport.use(
   new GoogleStrategy(
     {


### PR DESCRIPTION
Ensure environment variables are loaded by adding dotenv.config() at the top of passportConfig.ts. This resolves the issue where missing environment variables resulted in OAuth2Strategy errors.

### Related Issue
Closes #69