### PR TITLE
Add query parameter "expense-group-id" to "expenses" controller

### DIFF
--- a/server/src/controllers/expense.controller.ts
+++ b/server/src/controllers/expense.controller.ts
@@ -50,7 +50,16 @@ const getExpenseById = async (req: Request, res: Response) => {
 
 const getExpenses = async (req: Request, res: Response) => {
   try {
-    const expenses = await prisma.expense.findMany();
+    const filterExpenseGroupId = req.query["expense-group-id"];
+
+    const expenses = await prisma.expense.findMany({
+      where: filterExpenseGroupId // if this query param is not in URL, all records will be returned
+        ? {
+            expenseGroupId: { equals: Number(filterExpenseGroupId) },
+          }
+        : {},
+    });
+
     res.status(200).json(expenses);
   } catch (e) {
     res.status(500).json({ error: e });


### PR DESCRIPTION

Expenses can now be filtered by a certain Expense Group Id

To be used on Expense Group Page (or similar), showing only relevant expenses.

Example:
Get
http://localhost:8080/api/v1/expenses?expense-group-id=2

