### PR TITLE
Added query parameter expense-group-id to participants controller

### DIFF
--- a/server/src/controllers/user-expense-group.controller.ts
+++ b/server/src/controllers/user-expense-group.controller.ts
@@ -52,7 +52,16 @@ const getUserExpenseGroupById = async (req: Request, res: Response) => {
 
 const getUserExpenseGroups = async (req: Request, res: Response) => {
   try {
-    const userExpenseGroups = await prisma.userExpenseGroup.findMany();
+    const filterExpenseGroupId = req.query["expense-group-id"];
+
+    const userExpenseGroups = await prisma.userExpenseGroup.findMany({
+      where: filterExpenseGroupId // if this query param is not in URL, all records will be returned
+        ? {
+            expenseGroupId: { equals: Number(filterExpenseGroupId) },
+          }
+        : {},
+    });
+
     res.status(200).json(userExpenseGroups);
   } catch (e) {
     res.status(500).json({ error: e });


### PR DESCRIPTION
Participants can now be filtered by a certain Expense Group Id

To be used on Expense Group Page (or similar), showing only relevant participants.

Example:
Get
http://localhost:8080/api/v1/participants?expense-group-id=2