### PR TITLE
Added user-id query parameter to expense-groups controller

### DIFF
--- a/server/src/controllers/expense-group.controller.ts
+++ b/server/src/controllers/expense-group.controller.ts
@@ -21,7 +21,7 @@ const getExpenseGroupById = async (req: Request, res: Response) => {
   try {
     const id = parseInt(req.params.id);
     const expenseGroup = await prisma.expenseGroup.findUnique({
-      where: {id},
+      where: { id },
     });
 
     if (expenseGroup) {
@@ -38,7 +38,19 @@ const getExpenseGroupById = async (req: Request, res: Response) => {
 
 const getExpenseGroups = async (req: Request, res: Response) => {
   try {
-    const expenseGroups = await prisma.expenseGroup.findMany();
+    const filterUserId = req.query["user-id"];
+
+    const expenseGroups = await prisma.expenseGroup.findMany({
+      include: { UserExpenseGroup: true },
+      where: filterUserId // if this query param is not in URL, all records will be returned
+        ? {
+            UserExpenseGroup: {
+              some: { userId: Number(filterUserId) },
+            },
+          }
+        : {},
+    });
+
     res.status(200).json(expenseGroups);
   } catch (e) {
     res.status(500).json({ error: e });


### PR DESCRIPTION

Added user-id query parameter to expense-groups controller.

Returns only the expense groups where "user-id" is a participant.

http://localhost:8080/api/v1/expense-groups?user-id=1