### PR TITLE
Add example dotenv to frontend

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,6 @@
+# environment variables must start with VITE_
+
+# use environment variables in the app with import.meta.env.{name_of_env_variable}
+# eg.: const serverBaseUrl = import.meta.env.VITE_SERVER_BASE_URL;
+
+VITE_SERVER_BASE_URL = http://localhost:8080

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+.env
 
 node_modules
 dist


### PR DESCRIPTION
# Add VITE_SERVER_BASE_URL and Comments to .env.example

## Description

This PR adds the `VITE_SERVER_BASE_URL` environment variable to the `.env.example` file along with comments explaining the correct usage and structure of environment variables in a Vite app. These comments ensure developers understand how to properly declare and use environment variables within the project.