### PR TITLE
fix(modal): preserve `createdBy` field when resetting form data

### DIFF
--- a/client/src/components/NewExpenseGroupsFormModal.tsx
+++ b/client/src/components/NewExpenseGroupsFormModal.tsx
@@ -40,13 +40,12 @@ export default function NewExpenseGroupFormModal({
       .then((res) => {
         console.log('Success!', res);
 
-        // clear input fields
-        setFormData({
+        setFormData((prevFormData) => ({
           name: '',
           description: '',
           budget: 0,
-          createdBy: 0,
-        });
+          createdBy: prevFormData.createdBy,
+        }));
 
         getExpenseGroups();
       })


### PR DESCRIPTION
# Fix: Preserve `createdBy` field when resetting form data

## Overview
This PR addresses an issue where the `createdBy` field was being reset along with other form fields after a successful form submission in the `NewExpenseGroupFormModal`. The field now retains the user's ID while other fields are cleared.

## Changes
- Updated form reset logic to preserve `createdBy` while clearing `name`, `description`, and `budget`.
- Kept the functionality to fetch updated expense groups after form submission.

## Impact
This fix ensures that the user's ID is retained during subsequent form submissions without affecting other input fields.

## Related Issue
- No related issue.
