### PR TITLE
Implement Modal Functionality for Adding Expense Groups

### DIFF
--- a/client/src/Pages/Home.tsx
+++ b/client/src/Pages/Home.tsx
@@ -15,6 +15,8 @@ const Home = () => {
   const { user } = useAuth();
 
   const [expenseGroups, setExpenseGroups] = useState<ExpenseGroup[]>([]);
+  const [isAddExpenseGroupModalOpen, setIsAddExpenseGroupModalOpen] =
+    useState(false);
 
   function getExpenseGroups() {
     if (user?.id) {
@@ -50,14 +52,29 @@ const Home = () => {
               key={expG.id}
               className="h-[50px] w-[290px] shadow-md cursor-pointer text-gray-50 bg-gray-300/50 rounded-md flex justify-center items-center"
             >
-              <p className="px-3.5 py-6 drop-shadow-[0_1.2px_1.2px_rgba(0,0,0,0.8)]">
+              <p className="px-3.5 py-6 text-center drop-shadow-[0_1.2px_1.2px_rgba(0,0,0,0.8)]">
                 {expG.name}
               </p>
             </div>
           ))}
       </div>
-      <NewExpenseGroupFormModal getExpenseGroups={getExpenseGroups}/>
-      <AddBtn />
+      {isAddExpenseGroupModalOpen && (
+        <NewExpenseGroupFormModal
+          getExpenseGroups={getExpenseGroups}
+          toggleModal={() =>
+            setIsAddExpenseGroupModalOpen(!isAddExpenseGroupModalOpen)
+          }
+        />
+      )}
+      <div>
+        {!isAddExpenseGroupModalOpen && (
+          <AddBtn
+            toggleModal={() =>
+              setIsAddExpenseGroupModalOpen(!isAddExpenseGroupModalOpen)
+            }
+          />
+        )}
+      </div>
     </div>
   );
 };

--- a/client/src/components/AddBtn.tsx
+++ b/client/src/components/AddBtn.tsx
@@ -1,6 +1,13 @@
-export default function AddBtn() {
+interface AddBtnProps {
+  toggleModal: () => void;
+}
+
+export default function AddBtn({ toggleModal }: AddBtnProps) {
   return (
-    <div className="fixed bottom-3 flex flex-col items-center">
+    <div
+      onClick={toggleModal}
+      className="flex flex-col items-center"
+    >
       <div className="bg-gray-300 size-14 rounded-full border border-indigo-900 shadow-md shadow-gray-600 relative cursor-pointer">
         <div className="bg-indigo-900 w-1 h-9 absolute top-2.5 left-[25px] rounded-md"></div>
         <div className="bg-indigo-900 h-1 w-9 absolute left-2.5 top-[25px] rounded-md"></div>

--- a/client/src/components/NewExpenseGroupsFormModal.tsx
+++ b/client/src/components/NewExpenseGroupsFormModal.tsx
@@ -5,10 +5,12 @@ import { serverBaseUrl } from '../config';
 
 interface NewExpenseGroupFormModalProps {
   getExpenseGroups: () => void;
+  toggleModal: () => void;
 }
 
 export default function NewExpenseGroupFormModal({
   getExpenseGroups,
+  toggleModal,
 }: NewExpenseGroupFormModalProps) {
   const url = `${serverBaseUrl}/api/v1/expense-groups`;
 
@@ -49,6 +51,7 @@ export default function NewExpenseGroupFormModal({
         });
 
         getExpenseGroups();
+        toggleModal();
       })
       .catch((error) => {
         console.error('Error fetching data:', error);
@@ -66,8 +69,14 @@ export default function NewExpenseGroupFormModal({
   }, [user?.id]);
 
   return (
-    <div className="fixed bottom-20">
-      <div className="bg-gray-300 h-[200px] w-[290px] border border-indigo-900 shadow-md shadow-gray-600 relative cursor-pointer">
+    <div
+      className="bg-black/80 flex justify-center items-center min-h-screen fixed bottom-0 left-0 w-full"
+      onClick={toggleModal}
+    >
+      <div
+        className="bg-gray-300 h-[200px] w-[290px] border border-indigo-900 shadow-md shadow-gray-600 relative cursor-pointer"
+        onClick={(e) => e.stopPropagation()}
+      >
         <form
           onSubmit={handleSubmit}
           className="p-3 flex flex-col"


### PR DESCRIPTION
## Pull Request: Implement Modal Functionality for Adding Expense Groups

### Overview
This pull request introduces the modal functionality for adding new expense groups in the application. The modal now allows users to add expense group details and can be toggled by clicking the associated button. It also supports closing the modal by clicking on the background, while preventing accidental closures when interacting with the form elements.

### Changes
- **Home.tsx**: 
  - Added state management for modal visibility.
  - Updated rendering logic to conditionally display the `NewExpenseGroupFormModal` based on the modal state.
  - Passed a `toggleModal` function to both `NewExpenseGroupFormModal` and `AddBtn` components.

- **AddBtn.tsx**:
  - Modified the button component to accept a `toggleModal` prop for handling modal visibility.
  - Adjusted the click handler to toggle the modal on button click.

- **NewExpenseGroupsFormModal.tsx**:
  - Updated the modal structure to allow closing by clicking the background.
  - Prevented the modal from closing when interacting with the form.
  - Called the `toggleModal` function upon successful form submission to close the modal.

### Notes
- Please review the changes and provide feedback.
