### PR TITLE
Refactor expense group card

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.7.7",
+        "lucide-react": "^0.446.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.26.2"
@@ -3072,6 +3073,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.446.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.446.0.tgz",
+      "integrity": "sha512-BU7gy8MfBMqvEdDPH79VhOXSEgyG8TSPOKWaExWGCQVqnGH7wGgDngPbofu+KdtVjPQBWbEmnfMTq90CTiiDRg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/merge2": {

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "axios": "^1.7.7",
+    "lucide-react": "^0.446.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.2"

--- a/client/src/Pages/Home.tsx
+++ b/client/src/Pages/Home.tsx
@@ -5,10 +5,12 @@ import AddBtn from '../components/AddBtn';
 import { useAuth } from '../hooks/useAuth';
 import NewExpenseGroupFormModal from '../components/NewExpenseGroupsFormModal';
 import { serverBaseUrl } from '../config';
+import ExpenseGroupCard from '../components/ExpenseGroupCard';
 
 interface ExpenseGroup {
   id: number;
   name: string;
+  userExpenseGroups: [];
 }
 
 const Home = () => {
@@ -32,6 +34,8 @@ const Home = () => {
     }
   }
 
+  console.log(expenseGroups);
+
   useEffect(() => {
     if (user?.id) {
       getExpenseGroups();
@@ -41,21 +45,11 @@ const Home = () => {
   console.log(expenseGroups);
 
   return (
-    <div className="flex min-h-screen items-center flex-col bg-indigo-600">
-      <p className="text-red-600 text-xl mt-3 mb-2">{user?.email}</p>
-      <p className="text-red-600 text-xl">id: {user?.id}</p>
+    <div className="flex min-h-screen items-center flex-col">
       <div className="flex flex-col gap-3 w-full justify-center items-center p-3">
         {expenseGroups.length > 0 &&
-          expenseGroups.map((expG) => (
-            // make a component for this data container
-            <div
-              key={expG.id}
-              className="h-[50px] w-[290px] shadow-md cursor-pointer text-gray-50 bg-gray-300/50 rounded-md flex justify-center items-center"
-            >
-              <p className="px-3.5 py-6 text-center drop-shadow-[0_1.2px_1.2px_rgba(0,0,0,0.8)]">
-                {expG.name}
-              </p>
-            </div>
+          expenseGroups.map((expenseGroup) => (
+            <ExpenseGroupCard expenseGroup={expenseGroup} />
           ))}
       </div>
       {isAddExpenseGroupModalOpen && (

--- a/client/src/components/AddBtn.tsx
+++ b/client/src/components/AddBtn.tsx
@@ -1,3 +1,5 @@
+import { CirclePlus } from 'lucide-react';
+
 interface AddBtnProps {
   toggleModal: () => void;
 }
@@ -8,11 +10,11 @@ export default function AddBtn({ toggleModal }: AddBtnProps) {
       onClick={toggleModal}
       className="flex flex-col items-center"
     >
-      <div className="bg-gray-300 size-14 rounded-full border border-indigo-900 shadow-md shadow-gray-600 relative cursor-pointer">
-        <div className="bg-indigo-900 w-1 h-9 absolute top-2.5 left-[25px] rounded-md"></div>
-        <div className="bg-indigo-900 h-1 w-9 absolute left-2.5 top-[25px] rounded-md"></div>
-      </div>
-      <p className="text-gray-50">Add an expense group</p>
+      <CirclePlus
+        size={42}
+        className="cursor-pointer text-neutral-800 hover:text-black"
+      />
+      <p className="text-neutral-800">Add an expense group</p>
     </div>
   );
 }

--- a/client/src/components/ExpenseGroupCard.tsx
+++ b/client/src/components/ExpenseGroupCard.tsx
@@ -1,0 +1,25 @@
+interface ExpenseGroup {
+  id: number;
+  name: string;
+  userExpenseGroups: [];
+}
+
+interface ExpenseGroupCardProps {
+  expenseGroup: ExpenseGroup;
+}
+
+const ExpenseGroupCard = ({ expenseGroup }: ExpenseGroupCardProps) => {
+  return (
+    <div
+      key={expenseGroup.id}
+      className="py-3 px-3 flex gap-1 flex-col w-[290px] shadow-md cursor-pointer text-neutral-800 rounded-md justify-center items-center"
+    >
+      <p className="text-lg text-left w-full">{expenseGroup.name}</p>
+      <p className="text-left w-full">
+        Number of participants: {expenseGroup.userExpenseGroups.length}
+      </p>
+    </div>
+  );
+};
+
+export default ExpenseGroupCard;


### PR DESCRIPTION
# Description

This PR introduces several improvements and refactors across the client application. Key changes include adding a new dependency, refactoring the `Home.tsx` file, creating a reusable `ExpenseGroupCard` component, and updating the `AddBtn` to use an icon from the `lucide-react` library.

## Changes

### Dependencies
- Added `lucide-react` as a new dependency to the client project.

### Refactor: Home Page
- Moved the rendering of individual expense groups to a new component (`ExpenseGroupCard`) for better reusability and maintainability.
- Removed inline JSX from `Home.tsx` for expense group cards and replaced it with the new component.

### Feature: Expense Group Card Component
- Created a new `ExpenseGroupCard` component that:
  - Accepts an `expenseGroup` prop.
  - Displays the name of the expense group and the number of participants.
  
### Update: Add Button
- Updated the `AddBtn` component:
  - Replaced the custom add button design with the `CirclePlus` icon from `lucide-react`.
  - Refined button styling for better accessibility and appearance.

## Checklist
- [x] Added `lucide-react` to `package.json` and `package-lock.json`.
- [x] Refactored `Home.tsx` to use `ExpenseGroupCard`.
- [x] Created a reusable `ExpenseGroupCard` component.
- [x] Updated `AddBtn` to use the `CirclePlus` icon.
