### PR TITLE
feature: navigete user to login if not logged in

### DIFF
--- a/client/src/Layouts/ProtectedLayout.tsx
+++ b/client/src/Layouts/ProtectedLayout.tsx
@@ -1,12 +1,25 @@
-// src/Layouts/ProtectedLayout.tsx
-
-import { Outlet } from 'react-router-dom';
+import { useEffect } from 'react';
+import { Outlet, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import { Toaster } from '@/components/ui/toaster';
 import Navbar from '@/components/Navbar';
 
 export const ProtectedLayout = () => {
   const { isLoggedIn } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      // Redirect to login if the user is not authenticated
+      navigate('/login');
+    }
+  }, [isLoggedIn, navigate]);
+
+  // Only render the layout if the user is logged in
+  if (!isLoggedIn) {
+    return null; // Prevent rendering protected components if not logged in
+  }
+
   return (
     <div>
       <Navbar isLoggedIn={isLoggedIn} />


### PR DESCRIPTION
### PR Title: Implement Protected Route Redirection

### Description
- Added logic in `ProtectedLayout` to redirect users to the login page if they are not authenticated.
- Utilized `useEffect` to monitor the `isLoggedIn` state from the `useAuth` hook.
- Prevented the rendering of protected components when the user is not logged in, enhancing security and user experience.

### Changes Made
- Updated `ProtectedLayout` to include authentication check and redirection.
- Ensured that protected routes are only accessible to logged-in users.
