### PR TITLE
Feat/126  update api endpoint expense groups invite participant send email and saves on invitations table

### DIFF
--- a/server/prisma/migrations/20241003114810_added_invitation_model/migration.sql
+++ b/server/prisma/migrations/20241003114810_added_invitation_model/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "invitations" (
+    "id" SERIAL NOT NULL,
+    "expense_group_id" INTEGER NOT NULL,
+    "sent_by" INTEGER NOT NULL,
+    "invited_email" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "invitations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "invitations_expense_group_id_invited_email_key" ON "invitations"("expense_group_id", "invited_email");
+
+-- AddForeignKey
+ALTER TABLE "invitations" ADD CONSTRAINT "invitations_sent_by_fkey" FOREIGN KEY ("sent_by") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "invitations" ADD CONSTRAINT "invitations_expense_group_id_fkey" FOREIGN KEY ("expense_group_id") REFERENCES "expense_groups"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/migrations/20241003114946_added_invitation_model/migration.sql
+++ b/server/prisma/migrations/20241003114946_added_invitation_model/migration.sql
@@ -1,0 +1,1 @@
+-- This is an empty migration.

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -38,8 +38,9 @@ model User {
   updatedAt DateTime @updatedAt @map("updated_at")
 
   // Lists from Relations
-  UserExpenseGroups UserExpenseGroup[] // Where this user is a Participant on 
-  ExpenseGroups     ExpenseGroup[] // Expense Groups created by this user
+  userExpenseGroups UserExpenseGroup[] // Where this user is a Participant on 
+  expenseGroups     ExpenseGroup[] // Expense Groups created by this user
+  invitations       Invitations[] // Invitations sent by this user
 
   // Mapping table name in DB
   @@map("users")
@@ -62,7 +63,8 @@ model ExpenseGroup {
   userExpenseGroups UserExpenseGroup[]
 
   // Relations
-  user User @relation(fields: [createdBy], references: [id])
+  user        User          @relation(fields: [createdBy], references: [id])
+  Invitations Invitations[]
 
   // Mapping table name in DB
   @@map("expense_groups")
@@ -126,4 +128,25 @@ model Expense {
 
   // Mapping table name in DB
   @@map("expenses")
+}
+
+model Invitation {
+  id             Int    @id @default(autoincrement())
+  expenseGroupId Int    @map("expense_group_id")
+  sentBy         Int    @map("sent_by") // the userId that sent the invitation
+  invitedEmail   String @map("invited_email") // the email that was invited
+  status         String // Invitation Status: "Pending" || "Accepted" || "Rejected"
+
+  // Timestamps
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  // Relations
+  sender       User         @relation(fields: [sentBy], references: [id])
+  expenseGroup ExpenseGroup @relation(fields: [expenseGroupId], references: [id], onDelete: Cascade)
+
+  // Constraints
+  @@unique([expenseGroupId, invitedEmail], name: "ExpenseGroup_Email_Unique") // for an ExpenseGroup, an email can be invited only once
+  // Mapping table name in DB
+  @@map("invitations")
 }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -40,7 +40,7 @@ model User {
   // Lists from Relations
   userExpenseGroups UserExpenseGroup[] // Where this user is a Participant on 
   expenseGroups     ExpenseGroup[] // Expense Groups created by this user
-  invitations       Invitations[] // Invitations sent by this user
+  invitations       Invitation[] // Invitations sent by this user
 
   // Mapping table name in DB
   @@map("users")
@@ -64,7 +64,7 @@ model ExpenseGroup {
 
   // Relations
   user        User          @relation(fields: [createdBy], references: [id])
-  Invitations Invitations[]
+  Invitations Invitation[]
 
   // Mapping table name in DB
   @@map("expense_groups")

--- a/server/src/controllers/expense-group.controller.ts
+++ b/server/src/controllers/expense-group.controller.ts
@@ -121,6 +121,44 @@ const deleteExpenseGroup = async (req: Request, res: Response) => {
 
 const inviteParticipant = async (req: Request, res: Response) => {
   try {
+    const { id, expenseGroupId, sentBy, invitedEmail } = req.body; // the user email that is being invited
+    // Create the new participant
+    const newInvitation = await prisma.invitation.create({
+      data: {
+        id,
+        expenseGroupId,
+        sentBy,
+        invitedEmail,
+        status: "Pending",
+      },
+    });
+
+    res.status(200).json(newInvitation);
+  } catch (e) {
+    res.status(500).json({ error: e });
+  }
+};
+
+const getPendingInvitations = async (req: Request, res: Response) => {
+  try {
+    const filterUserEmail = req.query["user-email"];
+
+    if (!filterUserEmail) {
+      res.status(404).json({ error: "user-email not received on URL" });
+      return;
+    }
+    const pendingInvitations = await prisma.invitation.findMany({
+      where: { invitedEmail: filterUserEmail.toString() },
+    });
+
+    res.status(200).json(pendingInvitations);
+  } catch (e) {
+    res.status(500).json({ error: e });
+  }
+};
+
+const inviteParticipant_OLD = async (req: Request, res: Response) => {
+  try {
     const id = parseInt(req.params.id); // the Expense Group Id
     const { expenseGroupId, userEmail } = req.body; // the user email that is being invited
 
@@ -172,4 +210,5 @@ export default {
   updateExpenseGroup,
   deleteExpenseGroup,
   inviteParticipant,
+  getPendingInvitations,
 };

--- a/server/src/routes/expense-group.route.ts
+++ b/server/src/routes/expense-group.route.ts
@@ -3,6 +3,8 @@ import ExpenseGroupController from "../controllers/expense-group.controller";
 
 const router = express.Router();
 
+router.get("/pending-invitations", ExpenseGroupController.getPendingInvitations);
+
 router.post("/", ExpenseGroupController.createExpenseGroup);
 router.get("/:id", ExpenseGroupController.getExpenseGroupById);
 router.get("/", ExpenseGroupController.getExpenseGroups);

--- a/server/test/Test Expense Splitter Web API.postman_collection.json
+++ b/server/test/Test Expense Splitter Web API.postman_collection.json
@@ -318,6 +318,14 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "Get Invitations by InvitedEmail",
+					"request": {
+						"method": "GET",
+						"header": []
+					},
+					"response": []
 				}
 			]
 		},
@@ -797,6 +805,11 @@
 		{
 			"key": "baseUrl",
 			"value": "http://localhost:8080/api/v1"
+		},
+		{
+			"key": "baseUrl_RenderDeploy\n",
+			"value": "https://v51-tier3-team-31.onrender.com/api/v1",
+			"type": "string"
 		}
 	]
 }


### PR DESCRIPTION
Updated Prisma schema, to include "Invitation" model

Added to end-points:
- /expense-groups/pending-invitations?user-email=testemail_002@gmail.com
- /expense-groups/invite-participant

the last one was updated, saving an Invitation on "Pending" status
Now with the body:

{
        "expenseGroupId": 1,
        "sentBy":1,
        "invitedEmail":"testemail_002@gmail.com",
        "status": "Pending"

}