### PR TITLE
feat/Added a new API endpoint for Balances

### DIFF
--- a/server/src/routes/expense-group.route.ts
+++ b/server/src/routes/expense-group.route.ts
@@ -8,6 +8,8 @@ router.get(
   ExpenseGroupController.getPendingInvitations
 );
 router.post("/reply-invitation", ExpenseGroupController.replyInvitation);
+router.get("/:id/balances", ExpenseGroupController.getBalances);
+
 router.post("/", ExpenseGroupController.createExpenseGroup);
 router.get("/:id", ExpenseGroupController.getExpenseGroupById);
 router.get("/", ExpenseGroupController.getExpenseGroups);
@@ -15,5 +17,7 @@ router.put("/:id", ExpenseGroupController.updateExpenseGroup);
 router.delete("/:id", ExpenseGroupController.deleteExpenseGroup);
 
 router.post("/invite-participant", ExpenseGroupController.inviteParticipant);
+
+router.get("/balances", ExpenseGroupController.getBalances);
 
 export default router;

--- a/server/test/Test Expense Splitter Web API.postman_collection.json
+++ b/server/test/Test Expense Splitter Web API.postman_collection.json
@@ -17,7 +17,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"User #1\",\r\n    \"googleId\": \"user0001@gmail.com\",\r\n    \"email\": \"user0001@gmail.com\"\r\n}",
+							"raw": "{\r\n    \"name\": \"User #1\",\r\n    \"googleId\": \"user001@gmail.com\",\r\n    \"email\": \"user0001@gmail.com\"\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -126,12 +126,12 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/user",
+							"raw": "{{baseUrl}}/users",
 							"host": [
 								"{{baseUrl}}"
 							],
 							"path": [
-								"user"
+								"users"
 							]
 						}
 					},
@@ -149,7 +149,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"Name ExpenseGroup Test #001\",\r\n    \"description\": \"Description ExpenseGroup Test #001\",\r\n    \"budget\": 2000,\r\n    \"createdBy\": 1\r\n}",
+							"raw": "{\r\n    \"name\": \"Name ExpenseGroup Test ZZZZ\",\r\n    \"description\": \"Description ExpenseGroup Test ZZZZ\",\r\n    \"budget\": 2000,\r\n    \"createdBy\": 1\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -213,13 +213,13 @@
 							}
 						},
 						"url": {
-							"raw": "{{baseUrl}}/expense-groups/1",
+							"raw": "{{baseUrl}}/expense-groups/40",
 							"host": [
 								"{{baseUrl}}"
 							],
 							"path": [
 								"expense-groups",
-								"1"
+								"40"
 							]
 						}
 					},
@@ -240,13 +240,13 @@
 							}
 						},
 						"url": {
-							"raw": "{{baseUrl}}/expense-groups/1",
+							"raw": "{{baseUrl}}/expense-groups/5",
 							"host": [
 								"{{baseUrl}}"
 							],
 							"path": [
 								"expense-groups",
-								"1"
+								"5"
 							]
 						}
 					},
@@ -299,7 +299,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"expenseGroupId\": 1,\r\n    \"userEmail\": \"newusername@test.com\"\r\n}",
+							"raw": "{\r\n    \"expenseGroupId\": 15,\r\n    \"invitedEmail\": \"username005@test.com\",\r\n    \"sentBy\": 1\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -323,15 +323,69 @@
 					"name": "Get Invitations by InvitedEmail",
 					"request": {
 						"method": "GET",
-						"header": []
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/expense-groups/pending-invitations?user-email=username005@test.com",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"expense-groups",
+								"pending-invitations"
+							],
+							"query": [
+								{
+									"key": "user-email",
+									"value": "username005@test.com"
+								}
+							]
+						}
 					},
 					"response": []
 				},
 				{
 					"name": "Reply to an Invitation",
 					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"invitationId\": 20, \r\n    \"reply\": \"Accepted\" // Must be  \"Accepted\" or \"Declined\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/expense-groups/reply-invitation",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"expense-groups",
+								"reply-invitation"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Balances",
+					"request": {
 						"method": "GET",
-						"header": []
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/expense-groups/40/balances",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"expense-groups",
+								"40",
+								"balances"
+							]
+						}
 					},
 					"response": []
 				}
@@ -347,7 +401,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"userId\": 1,\r\n    \"expenseGroupId\": 1,\r\n    \"contributionWeight\": 0,\r\n    \"description\": \"Description Sample\",\r\n    \"locked\": false,\r\n    \"lockedAt\": \"2024-09-10T17:43:02.424Z\"\r\n}",
+							"raw": "{\r\n    \"userId\": 5,\r\n    \"expenseGroupId\": 40,\r\n    \"contributionWeight\": 0,\r\n    \"description\": \"Description Sample\",\r\n    \"locked\": false,\r\n    \"lockedAt\": \"2024-09-10T17:43:02.424Z\"\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -355,12 +409,12 @@
 							}
 						},
 						"url": {
-							"raw": "{{baseUrl}}/user-expense-group",
+							"raw": "{{baseUrl}}/participants",
 							"host": [
 								"{{baseUrl}}"
 							],
 							"path": [
-								"user-expense-group"
+								"participants"
 							]
 						}
 					},
@@ -473,12 +527,18 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/participants",
+							"raw": "{{baseUrl}}/participants?expense-group-id=40",
 							"host": [
 								"{{baseUrl}}"
 							],
 							"path": [
 								"participants"
+							],
+							"query": [
+								{
+									"key": "expense-group-id",
+									"value": "40"
+								}
 							]
 						}
 					},
@@ -496,7 +556,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"Category #1\"\r\n}",
+							"raw": "{\r\n    \"name\": \"Category #001\"\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -504,12 +564,12 @@
 							}
 						},
 						"url": {
-							"raw": "{{baseUrl}}/category",
+							"raw": "{{baseUrl}}/categories",
 							"host": [
 								"{{baseUrl}}"
 							],
 							"path": [
-								"category"
+								"categories"
 							]
 						}
 					},
@@ -560,13 +620,13 @@
 							}
 						},
 						"url": {
-							"raw": "{{baseUrl}}/category/2",
+							"raw": "{{baseUrl}}/categories/7",
 							"host": [
 								"{{baseUrl}}"
 							],
 							"path": [
-								"category",
-								"2"
+								"categories",
+								"7"
 							]
 						}
 					},
@@ -628,7 +688,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n\r\n      \"expenseGroupId\":1,\r\n      \"name\":\"Expense Name 001\",\r\n      \"description\":\"Expense Dscription 001\",\r\n      \"categoryId\": 1,\r\n      \"amount\": 500,\r\n      \"createdBy\": 1,\r\n      \"receiptURL\": \"htps://test.test/test001\"\r\n}",
+							"raw": "{\r\n      \"expenseGroupId\":40,\r\n      \"name\":\"Expense Name 003\",\r\n      \"description\":\"Expense Dscription 003\",\r\n      \"categoryId\": 1,\r\n      \"amount\": 800,\r\n      \"createdBy\": 5,\r\n      \"receiptURL\": \"htps://test.test/test003\"\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -654,7 +714,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "    {\r\n        \r\n        \"expenseGroupId\": 1,\r\n        \"name\": \"Expense Name 002\",\r\n        \"description\": \"Expense Dscription 002\",\r\n        \"categoryId\": 1,\r\n        \"amount\": \"500\",\r\n        \"createdBy\": 1,\r\n        \"receiptURL\": \"htps://test.test/test002\"\r\n      \r\n    }",
+							"raw": "    {\r\n        \r\n       \"expenseGroupId\":40,\r\n      \"name\":\"Expense Name 001\",\r\n      \"description\":\"Expense Dscription 001\",\r\n      \"categoryId\": 1,\r\n      \"amount\": 100,\r\n      \"createdBy\": 1,\r\n      \"receiptURL\": \"htps://test.test/test001\"\r\n      \r\n    }",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -662,13 +722,13 @@
 							}
 						},
 						"url": {
-							"raw": "{{baseUrl}}/expenses/2",
+							"raw": "{{baseUrl}}/expenses/10",
 							"host": [
 								"{{baseUrl}}"
 							],
 							"path": [
 								"expenses",
-								"2"
+								"10"
 							]
 						}
 					},
@@ -754,7 +814,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/expenses?expense-group-id=1",
+							"raw": "{{baseUrl}}/expenses?expense-group-id=40",
 							"host": [
 								"{{baseUrl}}"
 							],
@@ -764,7 +824,7 @@
 							"query": [
 								{
 									"key": "expense-group-id",
-									"value": "1"
+									"value": "40"
 								}
 							]
 						}


### PR DESCRIPTION
Added a new API endpiont 
...api/v1/expense-groups/{expenseGroupId}/balances

Returns Balances for a certain ExpenseGroup, including some extra data

Postman Collection updated (server/test folder)

Note:
By now, is assuming that all expenses will be equally divided.
Also, is assuming that the user that created the Expense is the one that paid it (needs to be refactored)
**To be discussed:
The expense should have a reference to a participant. And these Balances should be grouped by this new "participantId" instead of by "createdBy" (the current behavior, after this PR). A user can create an expense paid by another user.**


This is a sample of returned data:

{
    "expenseGroupId": 40,
    "totalExpenses": 1250,
    "numOfParticipants": 4,
    "individualContribution": 312.5,
    "totalExpensesByUser": {
        "1": 100,
        "2": 150,
        "3": 200,
        "5": 800
    },
    "balances": [
        {
            "userId": 1,
            "userName": "Attila Ádám Honvédő",
            "userEmail": "adam.honvedo@gmail.com",
            "amountPaid": 100,
            "balance": -212.5
        },
        {
            "userId": 2,
            "userName": "Ádám Honvédő",
            "userEmail": "honvedoadamkj@gmail.com",
            "amountPaid": 150,
            "balance": -162.5
        },
        {
            "userId": 3,
            "userName": "",
            "userEmail": "newusername@test.com",
            "amountPaid": 200,
            "balance": -112.5
        },
        {
            "userId": 5,
            "userName": "User #1",
            "userEmail": "user0001@gmail.com",
            "amountPaid": 800,
            "balance": 487.5
        }
    ]
}