### PR TITLE
setting default category to the first element of category array

### DIFF
--- a/client/src/components/NewExpenseFormModal.tsx
+++ b/client/src/components/NewExpenseFormModal.tsx
@@ -104,6 +104,10 @@ export default function NewExpenseFormModal({
     if (expenseGroupId) {
       form.setValue('expenseGroupId', Number(expenseGroupId));
     }
+    if (categories[0].id) {
+      const categoryIdNumber = categories[0].id;
+      form.setValue('categoryId', categoryIdNumber.toString());
+    }
   }, [user, form, expenseGroupId]);
 
   return (


### PR DESCRIPTION
setting default category to the first element of category array when adding a new expense. 