### PR TITLE
fix/(API) expense-groups/{id}/balances returns a null balances

### DIFF
--- a/server/src/controllers/expense-group.controller.ts
+++ b/server/src/controllers/expense-group.controller.ts
@@ -305,7 +305,7 @@ const getBalances = async (req: Request, res: Response) => {
             userEmail: participant.user.email,
             amountPaid: totalExpensesByUser[participant.userId],
             balance:
-              totalExpensesByUser[participant.userId] - individualContribution,
+              (totalExpensesByUser[participant.userId] || 0)- individualContribution,
           };
         }
       );


### PR DESCRIPTION
API endpoint:
...api/v1/expense-groups/{id}/balances 
Returns a null balances for participants that do not have expenses paid in this group

fix #147  