### PR TITLE
Improve User Experience with Thumbnail Support and Receipt Viewing Modal

### DIFF
--- a/client/src/components/CloudinaryUploadWidget.tsx
+++ b/client/src/components/CloudinaryUploadWidget.tsx
@@ -9,6 +9,7 @@ interface CloudinaryUploadWidgetProps {
   uwConfig: object;
   setPublicId: (publicId: string) => void;
   setImageUrl: (url: string) => void;
+  setThumbnailURL: (url: string) => void;
   setResponse: (response: null | 'success') => void;
 }
 
@@ -36,6 +37,7 @@ function CloudinaryUploadWidget({
   setPublicId,
   setImageUrl,
   setResponse,
+  setThumbnailURL,
 }: CloudinaryUploadWidgetProps) {
   const [loaded, setLoaded] = useState<boolean>(false);
 
@@ -66,6 +68,7 @@ function CloudinaryUploadWidget({
           if (!error && result && result.event === 'success') {
             console.log('Done! Here is the image info: ', result);
             setImageUrl(result.info.secure_url);
+            setThumbnailURL(result.info.thumbnail_url);
             setPublicId(result.info.public_id);
             setResponse(result.event);
           }

--- a/client/src/components/NewExpenseFormModal.tsx
+++ b/client/src/components/NewExpenseFormModal.tsx
@@ -42,6 +42,7 @@ export default function NewExpenseFormModal({
 
   const [publicId, setPublicId] = useState('');
   const [imageUrl, setImageUrl] = useState<string>('');
+  const [thumbnailURL, setThumbnailURL] = useState<string>('');
   const [imageUploadResponse, setImageUploadResponse] = useState<
     null | 'success'
   >(null);
@@ -88,7 +89,8 @@ export default function NewExpenseFormModal({
     categoryId: z.string(),
     amount: z.string(),
     createdBy: z.number(),
-    receiptURL: z.string().min(2),
+    receiptURL: z.string(),
+    receiptThumbnailURL: z.string(),
   });
 
   const form = useForm<z.infer<typeof FormSchema>>({
@@ -101,6 +103,7 @@ export default function NewExpenseFormModal({
       categoryId: '',
       expenseGroupId: 0,
       receiptURL: '',
+      receiptThumbnailURL: '',
     },
   });
 
@@ -142,10 +145,11 @@ export default function NewExpenseFormModal({
   }, [user, form, expenseGroupId]);
 
   useEffect(() => {
-    if (imageUrl) {
+    if (imageUrl || thumbnailURL) {
       form.setValue('receiptURL', imageUrl);
+      form.setValue('receiptThumbnailURL', thumbnailURL);
     }
-  }, [imageUrl]);
+  }, [imageUrl, thumbnailURL]);
 
   return (
     <div
@@ -275,6 +279,7 @@ export default function NewExpenseFormModal({
             <div className="flex items-center gap-3">
               <CloudinaryUploadWidget
                 setImageUrl={setImageUrl}
+                setThumbnailURL={setThumbnailURL}
                 setResponse={setImageUploadResponse}
                 uwConfig={uwConfig}
                 setPublicId={setPublicId}

--- a/client/src/components/Photos.tsx
+++ b/client/src/components/Photos.tsx
@@ -1,6 +1,8 @@
 import { Expense } from '@/types/expense';
 import { DollarSign, Image } from 'lucide-react';
 import { Card, CardContent } from './ui/card';
+import ReceiptModal from './ReceiptModal';
+import { useState } from 'react';
 
 interface PhotosProps {
   expenses: Expense[] | undefined;
@@ -8,8 +10,6 @@ interface PhotosProps {
 
 const Photos = ({ expenses }: PhotosProps) => {
   let hasExpenses = expenses && expenses.length > 0;
-
-  console.log(expenses);
 
   if (!expenses) {
     return 'no expenses';
@@ -51,44 +51,76 @@ const formatAmount = (amount: string | number | undefined): string => {
   return `$${numericAmount.toFixed(2)}`;
 };
 
-const ExpensePhotos = ({ expenses }: ExpensePhotosProps) => (
-  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-    {expenses.map((expense) => (
-      <Card
-        key={expense.id}
-        className="overflow-hidden"
-      >
-        <div className="relative aspect-[4/3]">
-          {expense.receiptURL ? (
-            <img
-              src={expense.receiptURL}
-              alt={`Receipt for ${expense.name}`}
-              className="object-cover w-full h-full"
-            />
-          ) : (
-            <div className="flex items-center justify-center w-full h-full bg-gray-100">
-              <DollarSign className="w-12 h-12 text-gray-400" />
+const ExpensePhotos = ({ expenses }: ExpensePhotosProps) => {
+  const [activeImage, setActiveImage] = useState<null | string>(null);
+
+  function openModal(imageSrc: string): void {
+    setActiveImage(imageSrc);
+    console.log(imageSrc);
+  }
+
+  function closeModal(): void {
+    setActiveImage(null);
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-6">
+      {activeImage && (
+        <ReceiptModal
+          imgUrl={activeImage}
+          closeModal={closeModal}
+        />
+      )}
+      {expenses.map((expense) => (
+        <Card
+          onClick={() => openModal(expense.receiptURL)}
+          key={expense.id}
+          className="overflow-hidden cursor-pointer hover:bg-gray-50 w-80 transition-colors rounded-md"
+        >
+          <div className="flex flex-row items-center">
+            <div className="w-24 h-full">
+              {expense.receiptThumbnailURL ? (
+                <img
+                  src={expense.receiptThumbnailURL}
+                  alt={`Receipt for ${expense.name}`}
+                  className="object-cover w-full min-w-24 h-full p-1 rounded-md"
+                />
+              ) : (
+                <div className="flex items-center justify-center w-full h-full bg-gray-100">
+                  <DollarSign className="w-8 h-8 text-gray-400" />
+                </div>
+              )}
             </div>
-          )}
-          <div className="absolute top-2 right-2">
-            <span className="px-2 py-1 text-sm font-semibold bg-black/50 text-white rounded-full">
-              {formatAmount(expense.amount)}
-            </span>
+            <div className="p-4 flex flex-col justify-between w-full">
+              <div className="flex flex-col">
+                <div className="flex justify-between  items-end mb-2">
+                  <h3 className="font-semibold text-lg truncate">
+                    {expense.name}
+                  </h3>
+                  <span className="ml-2 px-2 text-sm  font-semibold  text-slate-600 ">
+                    {formatAmount(expense.amount)}
+                  </span>
+                </div>
+                {expense.description && (
+                  <p className="text-sm text-slate-700 text-left w-full line-clamp-2">
+                    {expense.description}
+                  </p>
+                )}
+                <div className="flex mt-2">
+                <span className="text-xs  text-slate-500 text-left hover:underline  w-full">
+                  {new Date(expense.createdAt).toLocaleDateString()}
+                </span>
+                <span className="text-xs  text-blue-600 text-left hover:underline  w-full">
+                  View Receipt →
+                </span>
+                </div>
+              </div>
+            </div>
           </div>
-        </div>
-        <CardContent className="p-4">
-          <h3 className="font-semibold text-lg mb-1 truncate">
-            {expense.name}
-          </h3>
-          {expense.description && (
-            <p className="text-sm text-gray-500 line-clamp-2">
-              {expense.description}
-            </p>
-          )}
-        </CardContent>
-      </Card>
-    ))}
-  </div>
-);
+        </Card>
+      ))}
+    </div>
+  );
+};
 
 export default Photos;

--- a/client/src/components/ReceiptModal.tsx
+++ b/client/src/components/ReceiptModal.tsx
@@ -1,0 +1,26 @@
+interface ReceiptModalPropType {
+  imgUrl: string;
+  closeModal: () => void;
+}
+
+const ReceiptModal = ({ imgUrl, closeModal }: ReceiptModalPropType) => {
+  return (
+    <div
+      className="bg-black/80 z-30 flex justify-center items-center min-h-screen absolute top-0 left-0 w-full"
+      onClick={closeModal}
+    >
+      <div
+        className="max-w-full max-h-full"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <img
+          src={imgUrl}
+          className="mx-auto"
+          alt="receipt-image"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ReceiptModal;

--- a/client/src/types/expense.ts
+++ b/client/src/types/expense.ts
@@ -1,12 +1,13 @@
 export interface Expense {
-    id: number;
-    expenseGroupId: number;
-    name: string;
-    description: string;
-    categoryId: number;
-    amount: string; // This could be 'number' if the amount should be a numerical value.
-    createdBy: number;
-    receiptURL: string;
-    createdAt: string; // Can be 'Date' if parsed as a Date object
-    updatedAt: string; // Can be 'Date' if parsed as a Date object
-  }
+  id: number;
+  expenseGroupId: number;
+  name: string;
+  description: string;
+  categoryId: number;
+  amount: string;
+  createdBy: number;
+  receiptURL: string;
+  createdAt: string;
+  updatedAt: string;
+  receiptThumbnailURL: string;
+}

--- a/server/prisma/migrations/20241010124012_thumbnail_url/migration.sql
+++ b/server/prisma/migrations/20241010124012_thumbnail_url/migration.sql
@@ -1,0 +1,1 @@
+-- This is an empty migration.


### PR DESCRIPTION
# Pull Request Description

## Overview
This PR introduces several enhancements related to expense handling, including the addition of thumbnail support for receipts and the implementation of a modal for viewing expense images in full screen. 

## Changes
- **Add Support for Thumbnail URL**: 
  - Implemented a new field for `receiptThumbnailURL` in the `Expense` interface to store thumbnail URLs for receipts.
  
- **Expense Form Updates**:
  - Updated the expense form to include a thumbnail URL field, allowing users to upload and preview thumbnail images alongside the main receipt.

- **Receipt Modal**:
  - Developed a modal component (`ReceiptModal`) that enables users to view uploaded receipt images in full screen.
  
- **Image Previews**:
  - Enhanced the expense photos display to show thumbnail images, improving user experience when reviewing expenses.

## Motivation
These changes aim to improve the user interface and experience by making it easier to manage and view expense receipts. The addition of thumbnail images and a dedicated modal for full-screen viewing will enhance the overall functionality of the expense management feature.

## Related Commits
- feat: add support for setting thumbnail URL in Cloudinary upload widget
- feat(expense-form): add thumbnail URL field and support for image preview
- feat(expense-photos): add receipt modal and thumbnail support for expense images
- feat(photos): add receipt modal for viewing expense images in full screen
- feat(expense): add receiptThumbnailURL to Expense interface
