### PR TITLE
fix: remove unused CardContent import in Photos.tsx

### DIFF
--- a/client/src/components/Photos.tsx
+++ b/client/src/components/Photos.tsx
@@ -1,6 +1,6 @@
 import { Expense } from '@/types/expense';
 import { DollarSign, Image } from 'lucide-react';
-import { Card, CardContent } from './ui/card';
+import { Card } from './ui/card';
 import ReceiptModal from './ReceiptModal';
 import { useState } from 'react';
 


### PR DESCRIPTION
### PR Description

- Removed unused `CardContent` import from `client/src/components/Photos.tsx`.
