### PR TITLE
Feat/164 task api on invite participant api controller sent email to invited user

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -29,3 +29,8 @@ CLIENT_HOME_PAGE_URL=http://127.0.0.1:5173/
 GOOGLE_REDIRECT_ADDRESS='http://localhost:5173/home'
 
 NODE_ENV=development # production
+
+
+# To use on SMTP, with App Password authentication
+GOOGLE_ACCOUNT_EMAIL= # google email
+GOOGLE_APP_PASSWORD= # app password - must be generated at https://myaccount.google.com/u/3/apppasswords and google account must have 2FA enabled

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,10 +10,12 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^5.19.1",
+        "@types/nodemailer": "^6.4.16",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^5.0.0",
         "jsonwebtoken": "^9.0.2",
+        "nodemailer": "^6.9.15",
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
         "swagger-ui-express": "^5.0.1",
@@ -971,10 +973,18 @@
       "version": "22.5.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.4.tgz",
       "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.16",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.16.tgz",
+      "integrity": "sha512-uz6hN6Pp0upXMcilM61CoKyjT7sskBoOWpptkjjJp8jIMlTdc3xG01U7proKkXzruMS4hS0zqtHNkNPFB20rKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/oauth": {
@@ -2547,6 +2557,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/nodemailer": {
+      "version": "6.9.15",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.15.tgz",
+      "integrity": "sha512-AHf04ySLC6CIfuRtRiEYtGEXgRfa6INgWGluDhnxTZhHSKvrBu7lc1VVchQ0d8nPc4cFaZoPq8vkyNoZr0TpGQ==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -3820,7 +3839,6 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/server/package.json
+++ b/server/package.json
@@ -29,10 +29,12 @@
   },
   "dependencies": {
     "@prisma/client": "^5.19.1",
+    "@types/nodemailer": "^6.4.16",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^5.0.0",
     "jsonwebtoken": "^9.0.2",
+    "nodemailer": "^6.9.15",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
     "swagger-ui-express": "^5.0.1",

--- a/server/src/controllers/expense-group.controller.ts
+++ b/server/src/controllers/expense-group.controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { prisma } from "../server";
+import { sendEmail } from "../utils/emailUtils"; // Updated import
 import { computeBalances } from "../useCases/computeBalances";
-
 import { computePayments } from "../useCases/computePayments";
 
 const createExpenseGroup = async (req: Request, res: Response) => {
@@ -134,6 +134,23 @@ const inviteParticipant = async (req: Request, res: Response) => {
         invitedEmail,
       },
     });
+
+    try {
+      await sendEmail(
+        invitedEmail,
+        "You were invited to be part of a SplitIt Expense Group",
+        `You were invited to be part of a SplitIt Expense Group (id: ${expenseGroupId})
+        Please click here to Accept.
+        Please click here to Decline.
+        
+        Thanks
+        SplitIt Team`
+      );
+
+      console.log("Email sent to: " + invitedEmail);
+    } catch (error) {
+      console.log("Error sending email: " + error);
+    }
 
     res.status(200).json(newInvitation);
   } catch (e) {

--- a/server/src/utils/emailUtils.ts
+++ b/server/src/utils/emailUtils.ts
@@ -7,15 +7,18 @@ const transporter = nodemailer.createTransport({
   host: "smtp.gmail.com",
   port: 587,
   secure: false, // true for 465, false for other ports
+
+  authMethod: "plain",
+
   auth: {
-    user: process.env.GOOGLE_USER,
+    user: process.env.GOOGLE_ACCOUNT_EMAIL,
     pass: process.env.GOOGLE_APP_PASSWORD,
   },
 });
 
 export const sendEmail = async (to: string, subject: string, text: string) => {
   const mailOptions = {
-    from: process.env.GOOGLE_USER,
+    from: process.env.GOOGLE_ACCOUNT_EMAIL,
     to,
     subject,
     text,

--- a/server/src/utils/emailUtils.ts
+++ b/server/src/utils/emailUtils.ts
@@ -1,0 +1,30 @@
+import nodemailer from "nodemailer";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const transporter = nodemailer.createTransport({
+  host: "smtp.gmail.com",
+  port: 587,
+  secure: false, // true for 465, false for other ports
+  auth: {
+    user: process.env.GOOGLE_USER,
+    pass: process.env.GOOGLE_APP_PASSWORD,
+  },
+});
+
+export const sendEmail = async (to: string, subject: string, text: string) => {
+  const mailOptions = {
+    from: process.env.GOOGLE_USER,
+    to,
+    subject,
+    text,
+  };
+
+  try {
+    await transporter.sendMail(mailOptions);
+    console.log("Email sent successfully");
+  } catch (error) {
+    console.error("Error sending email:", error);
+  }
+};


### PR DESCRIPTION
Added a new utility function on /utils/sendEmail.ts.

Updated invite-participant controller to send an email to invited user.

Please add this new variables to .env file (see .env.example)
GOOGLE_ACCOUNT_EMAIL=<google email>
GOOGLE_APP_PASSWORD=<app password>

Note:
The email body do not contains yet links to Accept/Decline - TBD